### PR TITLE
Remove other place data from inspections summary graph

### DIFF
--- a/components/cards/TestedNumberCard.vue
+++ b/components/cards/TestedNumberCard.vue
@@ -1,13 +1,11 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
-    <time-stacked-bar-chart
+    <time-bar-chart
       :title="$t('検査実施数')"
       :title-id="'number-of-tested'"
-      :chart-id="'time-stacked-bar-chart-inspections'"
+      :chart-id="'time-bar-chart-inspections'"
       :chart-data="inspectionsGraph"
       :date="Data.inspections_summary.date"
-      :items="inspectionsItems"
-      :labels="inspectionsLabels"
       :unit="$t('件.tested')"
     />
     <!-- 件.tested = 検査数 -->
@@ -16,29 +14,27 @@
 
 <script>
 import Data from '@/data/data.json'
-import TimeStackedBarChart from '@/components/TimeStackedBarChart.vue'
+import formatGraph from '@/utils/formatGraph'
+import TimeBarChart from '@/components/TimeBarChart.vue'
 
 export default {
   components: {
-    TimeStackedBarChart
+    TimeBarChart
   },
   data() {
     // 検査実施日別状況
-    const inspectionsGraph = [
-      Data.inspections_summary.data['県内'],
-      Data.inspections_summary.data['その他']
-    ]
-    const inspectionsItems = [
-      this.$t('県内発生（疑い例・接触者調査）'),
-      this.$t('その他（チャーター便・クルーズ船）')
-    ]
-    const inspectionsLabels = Data.inspections_summary.labels
+    // '県内'の値のみ利用する
+    const zipedSummaryData = Data.inspections_summary.labels.map((e, i) => {
+      return {
+        日付: e,
+        小計: Data.inspections_summary.data['県内'][i]
+      }
+    })
+    const inspectionsGraph = formatGraph(zipedSummaryData)
 
     const data = {
       Data,
-      inspectionsGraph,
-      inspectionsItems,
-      inspectionsLabels
+      inspectionsGraph
     }
     return data
   }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #33

## 📝 関連する issue / Related Issues
- #31 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- inspections_summary内の `その他` のデータを捨て `県内` データのみ利用するようにした。
- `TimeStackedBarChart` を `TimeBarChart` に変更した。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

### Before  
<img src="https://user-images.githubusercontent.com/6281583/78977656-72fe6c80-7b53-11ea-84e3-dd060ffb5338.png" width="300px">

### After  
<img src="https://user-images.githubusercontent.com/6281583/78977161-9d035f00-7b52-11ea-9fa8-f935b4009e8d.png" width="300px">