### PR TITLE
Added Schema.org structured data for COVID-19

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -82,7 +82,74 @@ export default Vue.extend({
   },
   head(): MetaInfo {
     return {
-      title: this.$t('福島県内の最新感染動向') as string
+      title: this.$t('福島県内の最新感染動向') as string,
+      __dangerouslyDisableSanitizers: ['script'],
+      script: [
+        {
+          innerHTML: `{
+              "@context": "https://schema.org",
+              "@type": "SpecialAnnouncement",
+              "name": "福島県内の新型コロナウイルス感染動向",
+              "text": "福島県内における新型コロナウイルスの陽性患者数や属性、PCR検査数などをお知らせしています。",
+              "url": "https://fukushima-covid19.web.app/",
+              "datePosted": "2020-05-05T00:00",
+              "expires": "2021-03-31T23:59",
+              "spatialCoverage": [{
+                "@context":"https://schema.org/",
+                "@type": "AdministrativeArea",
+                "name": "福島県"
+              }],
+              "category": "https://www.wikidata.org/wiki/Q81068910",
+              "diseaseSpreadStatistics" : [{
+                "@type": "Dataset",
+                "name" : "福島県 新型コロナウイルス陽性患者属性",
+                "description" : "福島県が公式に発表した、新型コロナウイルス（COVID-19）陽性患者の公表日・居住地・年代・性別・退院・死亡に関するデータ。（注）チャーター機帰国者、クルーズ船乗客等は含まれていない（注）入院中には宿泊療養を含む",
+                "sameAs": "https://www.pref.fukushima.lg.jp/sec/21045c/covid19-opendata.html",
+                "license": "https://creativecommons.org/licenses/by/2.1/jp/",
+                "distribution" : {
+                    "@type": "DataDownload",
+                    "contentUrl": "https://storage.googleapis.com/fukushima-covid19/csv/patients.csv",
+                    "encodingFormat" : "text/csv"
+                }
+              },{
+                "@type": "Dataset",
+                "name" : "福島県 新型コロナウイルス検査件数",
+                "description" : "福島県が公式に発表した、新型コロナウイルス（COVID-19）におけるPCR検査件数の日次データ。（注）以下は検査実施数に含まれていない 1)チャーター機帰国者、クルーズ船乗客等 2)退院のための検査（注）速報値として公開するものであり、後日確定データとして修正される場合あり",
+                "sameAs": "https://www.pref.fukushima.lg.jp/sec/21045c/covid19-opendata.html",
+                "license": "https://creativecommons.org/licenses/by/2.1/jp/",
+                "distribution" : {
+                    "@type": "DataDownload",
+                    "contentUrl": "https://storage.googleapis.com/fukushima-covid19/csv/inspections.csv",
+                    "encodingFormat" : "text/csv"
+                }
+              },{
+                "@type": "Dataset",
+                "name" : "福島県 相談窓口 相談件数",
+                "description" : "福島県が公式に発表した、新型コロナウイルス（COVID-19）における受診相談窓口が受け付けた相談件数",
+                "sameAs": "https://www.pref.fukushima.lg.jp/sec/21045c/covid19-opendata.html",
+                "license": "https://creativecommons.org/licenses/by/2.1/jp/",
+                "distribution" : {
+                    "@type": "DataDownload",
+                    "contentUrl": "https://storage.googleapis.com/fukushima-covid19/csv/contacts.csv",
+                    "encodingFormat" : "text/csv"
+                }
+              },{
+                "@type": "Dataset",
+                "name" : "福島県 帰国者・接触者相談センター 相談件数",
+                "description" : "福島県が公式に発表した、新型コロナウイルス（COVID-19）における帰国者・接触者相談センターが受け付けた相談件数",
+                "sameAs": "https://www.pref.fukushima.lg.jp/sec/21045c/covid19-opendata.html",
+                "license": "https://creativecommons.org/licenses/by/2.1/jp/",
+                "distribution" : {
+                    "@type": "DataDownload",
+                    "contentUrl": "https://storage.googleapis.com/fukushima-covid19/csv/querents.csv",
+                    "encodingFormat" : "text/csv"
+                }
+              }]
+            }
+          `,
+          type: 'application/ld+json'
+        }
+      ]
     }
   }
 })

--- a/tool/functions/generate_data_function/main.py
+++ b/tool/functions/generate_data_function/main.py
@@ -77,11 +77,14 @@ def upload_json(bucket_name, destination_blob_name, data):
   blob = bucket.blob(destination_blob_name)
   blob.cache_control = 'max-age=10'
   blob.upload_from_string(data, content_type='application/json')
-  logging.info(
-      "File {} uploaded to {}.".format(
-          data, destination_blob_name
-      )
-  )
+
+
+def upload_csv(bucket_name, destination_blob_name, data):
+  storage_client = storage.Client()
+  bucket = storage_client.bucket(bucket_name)
+  blob = bucket.blob(destination_blob_name)
+  blob.cache_control = 'max-age=10'
+  blob.upload_from_string(data, content_type='text/csv')
 
 
 class Patient():
@@ -250,6 +253,7 @@ def generate_patiens_json():
   patients_file_latest_uri = patients_dir_list[-1]
   logging.info(patients_file_latest_uri)
   patients_csv_string, patients_csv_datetime = fetch_csv_as_string(patients_file_latest_uri)
+  upload_csv(GCP_PROJECT, 'csv/patients.csv', patients_csv_string)
   patients = csv_string_to_list(patients_csv_string)
   patients_data, patients_summary, discharges_summary, patient_dided, patient_discharged = generate_patiens_data(patients, patients_csv_datetime)
   DATETIME_LIST.append(patients_csv_datetime)
@@ -272,6 +276,7 @@ def generate_inspection_json():
   inspections_file_latest_uri = inspections_dir_list[-1]
   logging.info(inspections_file_latest_uri)
   inspections_csv_string, inspections_csv_datetime = fetch_csv_as_string(inspections_file_latest_uri)
+  upload_csv(GCP_PROJECT, 'csv/inspections.csv', inspections_csv_string)
   inspections = csv_string_to_list(inspections_csv_string)
   data_perf, data_etc, labels, total_num = generate_inspections_data(inspections)
   DATETIME_LIST.append(inspections_csv_datetime)
@@ -289,6 +294,7 @@ def generate_contacts_json():
   contacts_file_latest_uri = contacts_dir_list[-1]
   logging.info(contacts_file_latest_uri)
   contacts_csv_string, contacts_csv_datetime = fetch_csv_as_string(contacts_file_latest_uri)
+  upload_csv(GCP_PROJECT, 'csv/contacts.csv', contacts_csv_string)
   contacts = csv_string_to_list(contacts_csv_string)
   contacts_data = generate_querents_data(contacts)
   DATETIME_LIST.append(contacts_csv_datetime)
@@ -302,6 +308,7 @@ def generate_querents_json():
   querents_file_latest_uri = querents_dir_list[-1]
   logging.info(querents_file_latest_uri)
   querents_csv_string, querents_csv_datetime = fetch_csv_as_string(querents_file_latest_uri)
+  upload_csv(GCP_PROJECT, 'csv/querents.csv', querents_csv_string)
   querents = csv_string_to_list(querents_csv_string)
   querents_data = generate_querents_data(querents)
   DATETIME_LIST.append(querents_csv_datetime)


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues

## 📝 関連する issue / Related Issues
- #70 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- data.jsonを書き出す中で、最新版のCSVをCloud Storageにホストするスクリプトを追加。
- indexにCOVID-19用の構造化データを追加
    - 主にこのサイトがCOVID-19に関するものであることと、各CSVをデータセットとしてCCライセンスにて提供。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
構造化データのチェックは通ったので、この後デプロイされたURLでチェック。
<img width="759" alt="Screen Shot 2020-05-05 at 1 29 38" src="https://user-images.githubusercontent.com/1407941/80990330-20be1c00-8e71-11ea-83f1-4c82654c0c15.png">
