### PR TITLE
fix: 陽性患者の患者の退院属性の英語表記の修正

### DIFF
--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -56,6 +56,7 @@ export default {
     for (const row of patientsTable.datasets) {
       row['居住地'] = this.$t(row['居住地'])
       row['性別'] = this.$t(row['性別'])
+      row['退院'] = this.$t(row['退院'])
 
       if (row['年代'] === '10歳未満') {
         row['年代'] = this.$t('10歳未満')
@@ -99,6 +100,7 @@ export default {
     for (const row of this.patientsTable.datasets) {
       row['居住地'] = this.$t(row['居住地'])
       row['性別'] = this.$t(row['性別'])
+      row['退院'] = this.$t(row['退院'])
 
       if (row['年代'] === '10歳未満') {
         row['年代'] = this.$t('10歳未満')


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #80 




## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `components/card/ConfirmedCasesAttributesCard.vue` で陽性患者の属性の翻訳をしている部分に退院の翻訳が抜けていたので付け足しました。


## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

- 日本語
![image](https://user-images.githubusercontent.com/30205140/83599450-23fb1380-a5a7-11ea-87e8-e0f545618e1d.png)


- English
![image](https://user-images.githubusercontent.com/30205140/83599470-307f6c00-a5a7-11ea-9151-fda16ff18365.png)


- やさしいにほんご
![image](https://user-images.githubusercontent.com/30205140/83599414-0f1e8000-a5a7-11ea-9803-1cece57b09c1.png)
